### PR TITLE
specify default domain

### DIFF
--- a/src/KerbalTelemetryModelProvider.js
+++ b/src/KerbalTelemetryModelProvider.js
@@ -42,6 +42,11 @@ define(
                                 name: "Value",
                                 units: measurement.units,
                                 format: format
+                            }],
+                            domains: [{
+                                key: "timestamp",
+                                name: "Kerbal Time",
+                                format: "number"
                             }]
                         }
                     };

--- a/src/KerbalTelemetrySeries.js
+++ b/src/KerbalTelemetrySeries.js
@@ -10,6 +10,7 @@ define(
                     return data.length;
                 },
                 getDomainValue: function (index, key) {
+                    if (!key) { key = 'timestamp'; }
                     return (data[index] || {})[key];
                 },
                 getRangeValue: function (index) {


### PR DESCRIPTION
Specify a default domain, as this parameter is considered optional.  Required for fixed position displays to properly update in real time.
